### PR TITLE
Hotfix/chat attachment

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/screens/chat/widgets/giphy_selector.dart
+++ b/lib/screens/chat/widgets/giphy_selector.dart
@@ -42,12 +42,6 @@ class GiphySelector extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Image.asset(
-            PathConstants.giphyAttribution,
-            width: 100,
-            height: 50,
-            fit: BoxFit.contain,
-          ),
           _buildSearchInput(context),
           SizedBox(height: $constants.insets.lg),
           BlocBuilder<GiphyBloc, GiphyState>(

--- a/lib/screens/chat/widgets/video_viewer.dart
+++ b/lib/screens/chat/widgets/video_viewer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:senpai/utils/constants.dart';
 import 'package:video_player/video_player.dart';
 
 @RoutePage()
@@ -116,6 +117,19 @@ class _VideoViewerState extends State<VideoViewerPage> {
             ),
           );
 
+    Widget closeButton = Positioned(
+      top: 40,
+      left: 10,
+      child: GestureDetector(
+        onTap: () => context.router.pop(),
+        child: Icon(
+          Icons.arrow_back_ios_rounded,
+          size: 30,
+          color: $constants.palette.white,
+        ),
+      ),
+    );
+
     return widget.controllable
         ? GestureDetector(
             onTap: toggleControls,
@@ -126,7 +140,7 @@ class _VideoViewerState extends State<VideoViewerPage> {
                   aspectRatio: videoController.value.aspectRatio,
                   child: VideoPlayer(videoController),
                 ),
-                if (showControls) ...[button],
+                if (showControls) ...[button, closeButton],
               ],
             ),
           )


### PR DESCRIPTION
- Adds a back button to exit the video preview
- Removes Giphy attribution graphic (doesn't remove asset and path from application)

NOTES: We can add a cleanup to completely remove this asset since it's adding to the bundle and we don't really need it as is.